### PR TITLE
LIBIIIF-158. Disable source caching.

### DIFF
--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -328,13 +328,13 @@ processor.ManualSelectionStrategy.fallback = Java2dProcessor
 # * `CacheStrategy` will download it into the source cache using
 #   FilesystemCache, which must also be configured. (This will perform a
 #   lot better than DownloadStrategy if you can spare the disk space.)
-processor.stream_retrieval_strategy = CacheStrategy
+processor.stream_retrieval_strategy = StreamStrategy
 
 # Controls how an incompatible StreamSource + FileProcessor combination is
 # dealt with.
 # * `DownloadStrategy` and `CacheStrategy` work the same as above.
 # * `AbortStrategy` causes the request to fail.
-processor.fallback_retrieval_strategy = CacheStrategy
+processor.fallback_retrieval_strategy = DownloadStrategy
 
 # Resolution of vector rasterization (of e.g. PDFs) at a scale of 1.
 processor.dpi = 150


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBIIIF-158